### PR TITLE
Display js errors for better debugging

### DIFF
--- a/app/routes/prototypes.js
+++ b/app/routes/prototypes.js
@@ -26,7 +26,11 @@ module.exports = function (app, hbs) {
     let handler = input => input
     try {
       handler = require(`../views/${req.params.prototype}.js`)
-    } catch (e) {}
+    } catch (e) {
+      if (e instanceof Error && e.code !== 'MODULE_NOT_FOUND') {
+        throw e
+      }
+    }
 
     return handler(Object.assign({}, req.body, req.query, {validated: req.session.validated || {}}), req)
   }

--- a/app/routes/prototypes.js
+++ b/app/routes/prototypes.js
@@ -63,7 +63,7 @@ module.exports = function (app, hbs) {
        .then(redirectOrRender(req, res))
        .catch(ex => {
          console.log(ex)
-         next()
+         next(ex)
        })
   })
 }


### PR DESCRIPTION
Fixes #36 

Alternative approach would be to check for file existence before the require but this seems a reasonable alternative.

Checked it works by introducing a syntax error in the code behind. There seem to be no functionality tests but happy to add some if you'd prefer.
